### PR TITLE
chore: fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### Find bugs in dev
 ![dev](https://raw.githubusercontent.com/pact-foundation/pact.io/master/pages/assets/img/icons/theme/devices/laptop-macbook.svg)
-Prevent integration issues before you commit, instead of in production or during integration test Prevent integration issues before you commit, instead of in production or during integration test
+Prevent integration issues before you commit, instead of in production or during integration test
 
 ### Deploy faster, safer & more often
 ![dev](https://raw.githubusercontent.com/pact-foundation/pact.io/master/pages/assets/img/icons/theme/general/thunder-move.svg) 


### PR DESCRIPTION
Removed duplicated sentence ("Prevent integration issues before you commit, instead of in production or during integration test") from the "Find bugs in dev" section of the file.
