### PR TITLE
feat(labels): update labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,124 @@
+- name: area:ci
+  description: Relating to the CI/CD workflow
+  color: "C2E0C6"
+
+- name: area:documentation
+  description: Relating to the documentation
+  color: "C2E0C6"
+  aliases:
+    - documentation
+
+- name: area:tests
+  description: Relating to the testing
+  color: "C2E0C6"
+
+- name: area:upstream
+  description: Relating to an upstream component
+  color: "C2E0C6"
+
+- name: difficulty:hard
+  description: A task requiring a lot of work and an in-depth understanding of the codebase
+  color: "0002C0"
+
+- name: difficulty:medium
+  description: A moderate task requiring a good understanding of the codebase
+  color: "7F68E0"
+
+- name: difficulty:easy
+  description: A simple task appropriate for newcomers to the codebase
+  color: "A79CF3"
+
+- name: priority:1-critical
+  description: Must be addressed immediately
+  color: "FF0000"
+
+- name: priority:2-high
+  description: Must be addressed as soon as possible
+  color: "FF3333"
+
+- name: priority:4-low
+  description: An optional, or otherwise 'nice-to-have' item
+  color: "FFDDDD"
+
+- name: status:awaiting-feedback
+  description: Waiting for more information from the reporter
+  colors: "000000"
+  aliases:
+    - awaiting feedback
+
+- name: status:duplicate
+  description: This issue or pull request already exists
+  color: "000000"
+  aliases:
+    - duplicate
+
+- name: status:invalid
+  description: This doesn't seem right
+  color: "000000"
+  aliases:
+    - invalid
+
+- name: status:triage
+  description: An item which has been recently created and needs to be triaged
+  color: "000000"
+  aliases:
+    - triage
+
+- name: status:wontfix
+  description: This will not be worked on
+  color: "000000"
+  aliases:
+    - wontfix
+
+- name: type:bug
+  description: Something isn't working
+  color: e41a1c
+  aliases:
+    - bug
+
+- name: type:feature
+  description: New feature
+  color: 377eb8
+  aliases:
+    - enhancement
+
+- name: type:fix
+  description: Fix to an issue
+  color: ff7f00
+
+- name: type:chore
+  description: Part of regular code upkeep
+  color: 984ea3
+
+- name: type:question
+  description: Further information is requested
+  color: 4daf4a
+  aliases:
+    - question
+
+- name: type:tracking
+  description: Tracks a more complicated task's progress across a number of other issues
+  color: ffff33
+
+- name: good first issue
+  description: Good for newcomers
+  color: "00FF00"
+
+- name: help wanted
+  description: Extra attention is needed
+  color: "FF00FF"
+
+- name: breaking change
+  description: This change will break existing functionality
+  color: "FF0000"
+
+- name: security
+  description: This change will affect security
+  color: "FF0000"
+
+- name: smartbear-supported
+  description: This issue is supported by SmartBear
+  color: "FF730B"
+  aliases:
+    - smartbear
+    - smartbear supported

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,14 +1,30 @@
-name: Apply Pact Foundation Label Policy
+name: Labels
+
 on:
-  schedule:
-    - cron: "0 12 * * *"
-  workflow_dispatch:
+  # For downstream repos, we want to run this on a schedule
+  # so that updates propagate automatically. Weekly is probably
+  # enough.
+  # schedule:
+  #   - cron: "20 0 * * 0"
+  push:
+    branches:
+      - master
+    paths:
+      - .github/labels.yml
+
 jobs:
-  mirror-labels:
+  sync-labels:
+    name: Synchronise labels
+
     runs-on: ubuntu-latest
-    env:
-      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
-    name: manage-your-labels
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: pact-foundation/manage-your-labels@v0.0.1
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Synchronize labels
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: |
+            https://raw.githubusercontent.com/pact-foundation/.github/main/.github/labels.yml
+            .github/labels.yml


### PR DESCRIPTION
I thought I would create a draft PR to get the ball rolling for updated labelling of issues. This is definitely intended to be a conversation started, and has been mostly copied from one of my other repos.

This would work as follows:

- This repo's `.github/labels.yml` contains the definition the labelling of issues across the Pact Foundation organisation. The changes are not pushed to each repository, and instead each repository must pull the changes from this repo. This allows each repo to adopt this at their own pace.
- Each downstream repo can have their own `.github/labels.yml` definition which extends this repo's `.github/labels.yml` to suite their specific neads.

The labels come in broad categories:

- ![#C2E0C6](https://placehold.co/15x15/C2E0C6/C2E0C6) **Area**: Tracks the part of the code that is being affected. Some universal categories including CI, documentation and testing.
- ~**Effort**:~ An estimate as to the amount of work, using a typical Fibonacci scale. While I have included this, it is more useful for tracking velocity and therefore I don't think is necessarily as important for open source projects.
  - ![#0002c0](https://placehold.co/15x15/0002c0/0002c0) 1
  - ![#4b32cd](https://placehold.co/15x15/4b32cd/4b32cd) 2
  - ![#6f56da](https://placehold.co/15x15/6f56da/6f56da) 3
  - ![#8c79e7](https://placehold.co/15x15/8c79e7/8c79e7) 5
  - ![#a79cf3](https://placehold.co/15x15/a79cf3/a79cf3) 8
  - ![#bfc0ff](https://placehold.co/15x15/bfc0ff/bfc0ff) 13
- **Difficulty**: I think this is a more appropriate alternative to the effort label above. It is more straightforward to understand, and better from a maintainer experience as they can gauge what they're in for before taking on an issue.
  - ![#0002c0](https://placehold.co/15x15/0002c0/0002c0) Hard
  - ![#7f68e0](https://placehold.co/15x15/7f68e0/7f68e0) Medium
  - ![#a79cf3](https://placehold.co/15x15/a79cf3/a79cf3) Easy
- **Priority**:
  - ![#ff0000](https://placehold.co/15x15/ff0000/ff0000) Critical
  - ![#ff3333](https://placehold.co/15x15/ff3333/ff3333) High
  - _implicit_
  - ![#ffdddd](https://placehold.co/15x15/ffdddd/ffdddd) Low
- **Status**: GitHub already keeps track of the open/closed status, but it can nice to have additional information as to the status.
  - ![#000000](https://placehold.co/15x15/000000/000000) Duplicate
  - ![#000000](https://placehold.co/15x15/000000/000000) Invalid
  - ![#000000](https://placehold.co/15x15/000000/000000) Awaiting Feedback
  - ![#000000](https://placehold.co/15x15/000000/000000) Triage
  - ![#000000](https://placehold.co/15x15/000000/000000) Wontfix
- **Type**: In effect, the conventional commit type, with a few additional types specific to issues.
  - ![#e41a1c](https://placehold.co/15x15/e41a1c/e41a1c) Bug
  - ![#377eb8](https://placehold.co/15x15/377eb8/377eb8) Feature
  - ![#ff7f00](https://placehold.co/15x15/ff7f00/ff7f00) Fix
  - ![#984ea3](https://placehold.co/15x15/984ea3/984ea3) Chore
  - ![#4daf4a](https://placehold.co/15x15/4daf4a/4daf4a) Question
  - ![#ffff33](https://placehold.co/15x15/ffff33/ffff33) Tracking
- And lastly, a few additional labels which don't otherwise fit in the above
  - ![#00FF00](https://placehold.co/15x15/00FF00/00FF00) good first issue
  - ![#FF00FF](https://placehold.co/15x15/FF00FF/FF00FF) help wanted
  - ![#FF0000](https://placehold.co/15x15/FF0000/FF0000) breaking change
  - ![#FF0000](https://placehold.co/15x15/FF0000/FF0000) security
  - ![#FF730B](https://placehold.co/15x15/FF730B/FF730B) smartbear supported