### PR TITLE
fix(labels): fix main -> master

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -26,5 +26,5 @@ jobs:
         uses: EndBug/label-sync@v2
         with:
           config-file: |
-            https://raw.githubusercontent.com/pact-foundation/.github/main/.github/labels.yml
+            https://raw.githubusercontent.com/pact-foundation/.github/master/.github/labels.yml
             .github/labels.yml


### PR DESCRIPTION
My initial PR incorrectly assumed the long-lived branch was `main`, but it is in fact `master`.